### PR TITLE
Fix problem with cloud storage picture sources #38

### DIFF
--- a/app/src/main/java/io/github/gsantner/memetastic/activity/MainActivity.java
+++ b/app/src/main/java/io/github/gsantner/memetastic/activity/MainActivity.java
@@ -41,13 +41,12 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import net.gsantner.opoc.util.FileUtils;
 import net.gsantner.opoc.util.SimpleMarkdownParser;
 
 import java.io.File;
 import java.io.FileDescriptor;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -398,13 +397,10 @@ public class MainActivity extends AppCompatActivity
 
                                 // Create temporary file in cache directory
                                 picturePath = File.createTempFile("image", "tmp", getCacheDir()).getAbsolutePath();
-                                FileOutputStream output = new FileOutputStream(picturePath);
-
-                                int read = 0;
-                                byte[] bytes = new byte[4096];
-                                while ((read = input.read(bytes)) != -1) {
-                                    output.write(bytes, 0, read);
-                                }
+                                FileUtils.writeFile(
+                                        new File(picturePath),
+                                        FileUtils.readCloseBinaryStream(input)
+                                );
                             }
                         } catch (IOException e) {
                             // nothing we can do here, null value will be handled below

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="main__get_picture_from_camera">Get picture from Camera</string>
     <string name="main__error_camera_cannot_start">Could not start Camera.</string>
     <string name="main__error_no_picture_selected">No picture was selected.</string>
+    <string name="main__error_fail_retrieve_picture">Could not load picture from storage.</string>
     <string name="main__share_meme_prompt">Share your Meme via…</string>
 
     <string name="main__donate">Donate</string>


### PR DESCRIPTION
Hi @gsantner ,

Initially I wanted to add a translation to this project, so I tried using it first (it's a great app!). Then, I encountered a problem when I tried to open an image from cloud sources, e.g.: Google Drive, which caused the application to crash on `NullPointerException`. From [StackOverflow](https://stackoverflow.com/questions/11764392/getting-an-image-from-gallery-on-from-the-picasa-google-synced-folders-doesn), this sounds like a common problem with KitKat devices and higher.

<img src="https://user-images.githubusercontent.com/2115470/31048444-fc9c4dbe-a657-11e7-8a76-c106f05eefa2.png" height="500">

This PR should fix this error without interrupting current code flow. Thanks!

This PR closes #38.
