### PR TITLE
Updated nb-rNO (Norwegian Bokmål (Norway)) translation

### DIFF
--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -9,21 +9,115 @@ You should have received a copy of the CC0 legalcode along with this
 work. If not, see <https://creativecommons.org/publicdomain/zero/1.0/>.
 -->
 <resources>
-
-
+    <string name="open_navdrawer">Åpne navigasjonsskuff</string>
+    <string name="close_navdrawer">Lukk navigasjonsskuff</string>
+    <string name="humans">Mennesker</string>
+    <string name="cartoon">Tegneserie</string>
+    <string name="animals">Dyr</string>
+    <string name="custom">Egen</string>
+    <string name="rage">Rekkevidde</string>
+    <string name="saved">Lagret</string>
+    <string name="favs">Favoritter</string>
     <string name="create">Opprett</string>
+    <string name="hidden">Skjult</string>
+    <string name="rows_with_title">Rader med tittel</string>
+    <string name="picture_grid">Bilderutenett</string>
+    <string name="get_picture_from_gallery">Hent bilde fra galleri</string>
+    <string name="get_picture_from_camera">Ta bilde med kamera</string>
+    <string name="error_cannot_start_camera">Kunne ikke starte kamera.</string>
+    <string name="error_picture_selection">Inget bilde valgt, tatt eller lagret.</string>
+    <string name="error_couldnot_load_picture_from_storage">Kunne ikke laste bilde fra lagring.</string>
     <string name="donate">Doner</string>
+    <string name="recommend">Anbefal</string>
     <string name="changelog">Endringslogg</string>
     <string name="exit">Avslutt</string>
+    <string name="yes">ja</string>
+    <string name="text_size">Tekststørrelse</string>
+    <string name="text_color">Tekstfarge</string>
+    <string name="border_color">Kantlinjefarge</string>
+    <string name="successfully_saved">Lagret</string>
+    <string name="top_caption">Topptekst</string>
+    <string name="bottom_caption">Bunntekst</string>
+    <string name="enter_caption">Skriv inn tekst</string>
+    <string name="font">Skrift</string>
+    <string name="keep_editing">Fortsett å redigere</string>
+    <string name="text">Tekst</string>
     <string name="size">Etter størrelse</string>
-    <string name="about">Om Markor</string>
+    <string name="background">Bakgrunn</string>
+    <string name="border">Kantlinje</string>
+    <string name="picture">Bilde</string>
+    <string name="about">Om</string>
+    <string name="developed_by">Utviklet av</string>
     <string name="licenses">Lisenser</string>
+    <string name="show_licenses">Vis lisenser</string>
     <string name="contributors">Bidragsytere</string>
+    <string name="more_information">Mer info</string>
     <string name="show_third_party_licenses">Vis tredjepartslisenser</string>
+    <string name="miscellaneous">Ymse</string>
+    <string name="gnu_gplv3_license">Vis friproglisens</string>
     <string name="settings">Innstillinger</string>
+    <string name="all_caps">Kun store bokstaver</string>
+    <string name="caps_off">Små og store bokstaver</string>
+    <string name="rotate">Roter</string>
+    <string name="render_quality">Opptegningskvalitet</string>
+    <string name="picture_quality_percent" formatted="false">Kvalitet og størrelse på bilder. Høyere betyr lengre innlastingstid. Avhengig av maskinvare og billedstørrelse kan det hende programmet ikke virker som forventet over 25%.</string>
+    <string name="clear_thumbnails">Tøm miniatyrbilder</string>
+    <string name="columns_portrait">Stående kolonner</string>
+    <string name="columns_landscape">Vannrette kolonner</string>
+    <string name="appearance">Utseende</string>
+    <string name="default_mode">Forvalgt modus</string>
+    <string name="functionality">Funksjonalitet</string>
+    <string name="save_when_pressing_back">Lagre når \"Tilbake\" trykkes</string>
+    <string name="padding">Luft</string>
+    <string name="overview">Oversikt</string>
     <string name="editor">Skriveprogram</string>
     <string name="hide_statusbar_at_this_view">Skjul statusfelt i denne visningen</string>
     <string name="hide_statusbar">Skjul statusfelt</string>
+    <string name="thumbnail_quality">Miniatyrbildekvalitet</string>
+    <string name="view_type">Visningstype</string>
+    <string name="show_in_device_gallery">Vis i galleri</string>
     <string name="language">Språk</string>
     <string name="language_change_restart_description">Endre programmets språk. Omstart kreves før endringer trer i effekt</string>
+    <string name="error_cannot_create_save_directory">Feil: Kan ikke opprette lagringsmappe</string>
+    <string name="other">Annet</string>
+    <string name="downloading">Laster ned</string>
+    <string name="downloading_failed">Nedlasting mislyktes</string>
+    <string name="unzipping">Pakker ut</string>
+    <string name="successfully_downloaded">Nedlastet</string>
+    <string name="download_latest_assets">Last ned nyeste elementer</string>
+    <string name="download_latest_assets_checking_description">Sjekker om det finnes nyere elementer</string>
+    <string name="palette">Palett</string>
+    <string name="presets">Forhåndsinnstillinger</string>
+    <string name="select_color">Velg farge</string>
+    <string name="code">Kode</string>
+    <string name="favourite">Favoritt</string>
+    <string name="remove_favourite">Fjern favoritt</string>
+    <string name="show_title">Vis tittel</string>
+    <string name="edit_title">Rediger tittel</string>
+    <string name="hide">Skjul</string>
+    <string name="unhide">Vis</string>
+    <string name="tap_here_to_add_caption">Trykk her for å legge til tekst</string>
+
+
+    <string name="search_meme__appspecific">Søk etter internettfenomen</string>
+    <string name="share_meme_via__appspecific">Del ditt internettfenomen via…</string>
+    <string name="save_meme__appspecific">Lagre internettfenomen</string>
+    <string name="share_meme__appspecific">Del internettfenomen</string>
+    <string name="create_meme__appspecific">Lag internettfenomen</string>
+    <string name="delete_meme__appspecific">Slett internettfenomen</string>
+    <string name="no_favourites_description__appspecific">Ingen favoritter enda.\n
+ Bruk stjerneknappen på internettfenomenmal for å legge til i favoritter.</string>
+    <string name="no_custom_templates_description__appspecific">Ingen egendefinerte maler enda. Plasserte malbilder her: %1$s</string>
+    <string name="no_memes_saved_description__appspecific">Ingen internettfenomen enda.\n
+ Bruk lagringsknappen øverst etter å ha redigert et internettfenomen.</string>
+    <string name="default_mode_description_description__appspecific">Forvalgt modus ved oppstart (Opprett, favoritter eller lagrede)</string>
+    <string name="press_back_again_to_stop_editing__appspecific">Trykk \"Tilbake\" igjen for å stoppe redigering av dette internettfenomenet. Det vil gå tapt hvis ikke allerede lagret.</string>
+    <string name="saved_meme_successfully__appspecific">Internettfenomen lagret. Vil du avslutte redigering av det?</string>
+    <string name="save_when_pressing_back_description__appspecific">Lagre endringer automatisk hvis \"Tilbake\" trykkes</string>
+    <string name="shuffle_meme_list_description__appspecific">Veksler listen over internettfenomen etter å ha valgt en kategori</string>
+    <string name="shuffle_meme_list__appspecific">Veksle internettfenomensliste</string>
+    <string name="view_type_memelist__appspecific">Sett visningstype (bilderutenett, rader med tittel)</string>
+    <string name="error_storage_permission__appspecific">Trenger lagringstilgang for å lagre internettfenomen og maler</string>
+    <string name="download_latest_assets_message__appspecific">Dette laster ned skrifter og internettfenomenmaler (omtrent 20 MB data).</string>
+    <string name="download_latest_assets_message_description__appspecific">I \"Innstillinger\" kan du også hente de siste elementene manuelt.</string>
 </resources>


### PR DESCRIPTION
Commit made via [Stringlate](https://lonamiwebs.github.io/stringlate/)