### PR TITLE
feat: add a dark mode which follow system mode

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -27,3 +27,4 @@ Where:
 * **[Nikola Perović]()**<br/>~° Serbian (Latin) translation
 * **[Jaime Muñoz](https://crowdin.com/profile/jmmartin_5)**<br/>~° Catalan translation
 * **[Billchenchina](https://github.com/billchenchina)**<br/>~° Simplified Chinese translation
+* **[Aurel Megnigbeto](https://aurelmegn.github.io)**<br/>~° Dark mode

--- a/app/src/main/res/layout/memecreate__moar_controls.xml
+++ b/app/src/main/res/layout/memecreate__moar_controls.xml
@@ -25,7 +25,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#eeeeee"
+    android:background="@color/default_activity_bg"
     android:fadeScrollbars="false"
     android:paddingLeft="@dimen/default_margin_2"
     android:paddingTop="@dimen/default_margin_2"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+/*#######################################################
+ *
+ *   Maintained by Gregor Santner, 2016-
+ *   https://gsantner.net/
+ *
+ *   License of this file: GNU GPLv3 (Commercial upon request)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+#########################################################*/
+-->
+<resources>
+    <color name="colorPrimary">@color/primary</color>
+    <color name="colorPrimaryDark">@color/primary_dark</color>
+    <color name="colorAccent">@color/accent</color>
+
+    <color name="default_activity_bg">@color/primary</color>
+    <color name="default_activity_bg_dark">@color/primary_dark</color>
+    <color name="empty_list_background_image">#E1E1E1</color>
+    <color name="empty_list_background_text">#757575</color>
+
+</resources>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+/*#######################################################
+ *
+ *   Maintained by Gregor Santner, 2016-
+ *   https://gsantner.net/
+ *
+ *   License of this file: GNU GPLv3 (Commercial upon request)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+#########################################################*/
+-->
+<resources>
+
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight">
+        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+
+        <item name="preferenceTheme">@style/AppTheme.PreferenceTheme</item>
+        <item name="android:windowBackground">@color/default_activity_bg_dark</item>
+    </style>
+
+    <style name="AppTheme.MemeCreatorEditTextOnLightBackground" parent="AppTheme.MemeCreatorEditText">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textCursorDrawable">@color/white</item>
+        <item name="android:textColorHint">@color/secondary_text</item>
+        <item name="colorControlNormal">@color/secondary_text</item>
+        <item name="colorControlActivated">@color/white</item>
+
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,7 +23,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -54,19 +54,23 @@
         <item name="colorControlActivated">@color/colorAccent</item>
     </style>
 
-    <style name="AppTheme.MemeCreatorEditTextOnLightBackground">
+    <style name="AppTheme.MemeCreatorEditTextOnLightBackground" parent="AppTheme.MemeCreatorEditText">
         <item name="android:textColor">@color/primary_text</item>
+        <item name="android:textCursorDrawable">@drawable/cursor_secondary</item>
+        <item name="android:textColorHint">@color/divider</item>
+        <item name="colorControlNormal">@color/divider</item>
+        <item name="colorControlActivated">@color/secondary_text</item>
+    </style>
+
+    <style name="AppTheme.MemeCreatorEditText">
+
         <item name="android:paddingLeft">@dimen/default_margin_2</item>
         <item name="android:paddingRight">@dimen/default_margin_2</item>
         <item name="android:inputType">textMultiLine</item>
         <item name="android:textSize">16sp</item>
-        <item name="android:textCursorDrawable">@drawable/cursor_secondary</item>
         <item name="android:gravity">center</item>
         <item name="android:ems">10</item>
         <item name="android:theme">@style/AppTheme.MemeCreatorEditTextOnLightBackground</item>
-        <item name="android:textColorHint">@color/divider</item>
-        <item name="colorControlNormal">@color/divider</item>
-        <item name="colorControlActivated">@color/secondary_text</item>
     </style>
 
     <style name="AppTheme.MemeCreatorCaptionText">
@@ -81,6 +85,7 @@
     <style name="AppTheme.PreferenceTheme.CategoryStyle" parent="Preference.Category">
         <item name="android:layout">@layout/opoc_pref_category_text</item>
     </style>
+
     <style name="LightTextToolbarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar">
         <item name="android:actionModeBackground">@color/primary_dark</item>
         <item name="actionModeBackground">@color/primary_dark</item>
@@ -89,7 +94,6 @@
         <item name="actionMenuTextColor">@android:color/white</item>
         <item name="android:textColorSecondary">@android:color/white</item>
     </style>
-
 
 
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         version_plugin_kotlin = "1.3.72"
         enable_plugin_kotlin = false
 
-        version_compileSdk = 28
+        version_compileSdk = 29
         version_buildTools = "28.0.3"
         version_minSdk = 17
 


### PR DESCRIPTION
I added a dark mode. It follows system settings

ref #216 

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
