### PR TITLE
fix screenshot urls in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,19 +76,16 @@ If you publish an app based on MemeTastic you MUST
 * Show that the app is not MemeTastic but a modified/custom version, MemeTastic developers are not related to modified versions and do not endorse your product
 
 ## Screenshots
-<div style="display:flex;" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/01.png" width="19%" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/02.png" width="19%" style="margin-left:10px;" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/03.png" width="19%" style="margin-left:10px;" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/04.png" width="19%" style="margin-left:10px;" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/05.png" width="19%" style="margin-left:10px;" >
+<div>
+	<img src="https://raw.githubusercontent.com/gsantner/memetastic/master/metadata/en-US/phoneScreenshots/01.jpg" width="24%" />
+	<img src="https://raw.githubusercontent.com/gsantner/memetastic/master/metadata/en-US/phoneScreenshots/02.jpg" width="24%" />
+	<img src="https://raw.githubusercontent.com/gsantner/memetastic/master/metadata/en-US/phoneScreenshots/03.jpg" width="24%" />
+	<img src="https://raw.githubusercontent.com/gsantner/memetastic/master/metadata/en-US/phoneScreenshots/04.jpg" width="24%" />
 </div>
 
-<div style="display:flex;" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/06.png" width="19%" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/07.png" width="19%" style="margin-left:10px;" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/08.png" width="19%" style="margin-left:10px;" >
-	<img src="https://raw.githubusercontent.com/gsantner/memetastic-metadata-latest/master/en-US/phoneScreenshots/09.png" width="19%" style="margin-left:10px;" >
+<div>
+	<img src="https://raw.githubusercontent.com/gsantner/memetastic/master/metadata/en-US/phoneScreenshots/05.jpg" width="48%" />
+	<img src="https://raw.githubusercontent.com/gsantner/memetastic/master/metadata/en-US/phoneScreenshots/06.jpg" width="48%" />
 </div>
 
 ## FAQ
@@ -170,4 +167,3 @@ Website: <https://www.reddit.com/r/MemeTemplatesOfficial/.compact>
 * [/r/BikiniBottomTwitter](https://www.reddit.com/r/BikiniBottomTwitter/.compact)
 * [/r/wowmemes](https://www.reddit.com/r/wowmemes/.compact)
 * [/r/de](https://www.reddit.com/r/de/.compact)
-


### PR DESCRIPTION
This changes the screenshot urls in README.md to point inside the `metadata/` directory in this repo, as the repo they currently point to seems to no longer exist. 

See result at https://github.com/giorgiga/memetastic/tree/fix-screenshot-urls

<!-- 
Hello, and thanks for contributing!

Please always do auto-reformat on code before creating a PR.
In Android-Studio do a right-click on java->Reformat and check the first two options.

After creating the PR please wait patiently till somebody from the team has time to give a review.
The top-priority requirement for this to get merged is, that building/tests don't fail.
If theres an continious integration system integrated in this project, you should see a colored checkmark in the PR window which tells the status.

## Contributors document
Add yourself! When adding your information to the `CONTRIBUTORS.md` file, please use the following format:

Schema:  **[Name](Reference)**<br/>~° Text 
Where: 
  * Name: username, first/lastname 
  * Reference: E-Mail, Webpage 
  * Text: Information about / kind of contribution 
Example:
* **[Nice Guy](http://niceguy.web)**<br/>~° German localization 
-->
